### PR TITLE
Fasttree

### DIFF
--- a/src/check_for_programs.py
+++ b/src/check_for_programs.py
@@ -8,12 +8,17 @@ def which_program(program):
     if filepath:
         if is_exe(program):
             return program
+        if is_exe(program.tolower()):
+            return program.tolower()
     else:
         for path in os.environ["PATH"].split(os.pathsep):
             exe_file = os.path.join(path, program)
             if is_exe(exe_file):
                 return exe_file
-
+            prog = program.lower()
+            exe_file = os.path.join(path, prog)
+            if is_exe(exe_file):
+                return exe_file
     return None
 
 if __name__ == "__main__":

--- a/src/find_good_clusters_for_concat.py
+++ b/src/find_good_clusters_for_concat.py
@@ -72,13 +72,15 @@ def check_info_table(tree):
     return
 
 def make_trim_trees(alignments):
-    if check_for_programs.which_program("FastTree") == None:
+    ft = check_for_programs.which_program("FastTree")
+    if ft == None:
         print colored.red("FastTree NOT IN PATH"),colored.red(emoticons.get_ran_emot("sad"))
         sys.exit(1)
     newalns = {}
     for i in alignments:
         print "making tree for",i
-        cmd = "FastTree -nt -gtr "+i+" > "+i.replace(".aln",".tre")+" 2> /dev/null"
+        #cmd = "FastTree -nt -gtr "+i+" > "+i.replace(".aln",".tre")+" 2> /dev/null"
+        cmd = ft+" -nt -gtr "+i+" > "+i.replace(".aln",".tre")+" 2> /dev/null"
         os.system(cmd)
         cmd = "python "+DI+"trim_tips.py "+i.replace(".aln",".tre")+" "+str(relcut)+" "+str(abscut)
         #print cmd


### PR DESCRIPTION
Regards #20. `which_program` now checks the original arg passed as well as a .tolower() version. Any successful match is returned.

`find_good_clusters_for_concat.py` uses this new function.

I should note that this still encounters errors, but not on my end (I think). I get the same errors with `FastTree` in my path. Here is an example:
```
Do you want to make trees and trim tips for these gene regions? y/n y
making tree for Hirundinidae_43148/clusters/cluster328.aln
  removing 8 tips
sh: 1: Syntax error: "(" unexpected
making tree for Hirundinidae_43148/clusters/cluster322.aln
  removing 8 tips
sh: 1: Syntax error: "(" unexpected
making tree for Hirundinidae_43148/clusters/cluster329.aln
  removing 8 tips
sh: 1: Syntax error: "(" unexpected
making tree for Hirundinidae_43148/clusters/cluster330.aln
  removing 8 tips
sh: 1: Syntax error: "(" unexpected
Traceback (most recent call last):
  File "/home/josephwb/Work/MacroBird_v2.0/PHLAWD/PyPHLAWD/src/change_id_to_ncbi_fasta_mult.py", line 18, in <module>
    for i in seq.read_fasta_file_iter(j):
  File "/home/josephwb/Work/MacroBird_v2.0/PHLAWD/PyPHLAWD/src/seq.py", line 110, in read_fasta_file_iter
    fl = open(filename,"r")
IOError: [Errno 2] No such file or directory: 'Hirundinidae_43148/clusters/cluster329.aln.ed'
```
Only empty tree files are written, but this might regard #11.